### PR TITLE
add conflict resolver

### DIFF
--- a/chrome/config.js
+++ b/chrome/config.js
@@ -286,6 +286,7 @@ var resolve_conflict = new Promise(function (resolve, reject) {
         console.log('resolved a conflict with bilibili helper');
         resolve();
     }, function() {
+        console.warn('*** the error above is harmless and you can ignore it with no worries ***');
         resolve();
     });
 });


### PR DESCRIPTION
目前 Unblock Youku 对 bilibili.com 视频的处理方法是统一加上大陆 IP 的 header, 然而 bilibili.com 部分地区的视频是只针对海外/港澳台地区的 (如: http://www.bilibili.com/video/av2965263/ -> http://interface.bilibili.com/playurl?cid=4643089&type=flv&appkey=95acd7f6cc3392f3), 同时 Unblock Youku 在细分上还有一些问题.

我的针对 bilibili.com 的综合辅助性扩展「[哔哩哔哩助手](https://chrome.google.com/webstore/detail/kpbnombpnpcffllnianjibmpadjolanh)」内包含了针对视频的细分, 但是因为同样需要写 request header, 导致和 Unblock Youku 冲突. 具体警告见附图:

![Warning Screenshot](https://cloud.githubusercontent.com/assets/1730305/10349213/5701e49a-6d0b-11e5-943c-657ffabdf8b7.png)

更多讨论: https://github.com/zacyu/bilibili-helper/issues/59 https://github.com/zacyu/bilibili-helper/issues/63 

此 pull request 意在提供一个不影响彼此原有功能解的情况下的解决方案, 即由 Unblock Youku 判断「哔哩哔哩助手」是否存在, 若存在则将去除通配符 URL 列表中所有 bilibili.com 域下的项目. 同时 conflict resolver 提供一个可扩展的模式, 允许将来当 Unblock Youku 与其它扩展冲突时进行类似的操作.