### PR TITLE
Fix issues/491 by disabling auto `buf.toString()` within "request"

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -151,6 +151,7 @@ function http_req_handler(client_request, client_response) {
     var proxy_request_headers = server_utils.filter_request_headers(client_request.headers);
     proxy_request_headers.Host = target.host;
     var proxy_request_options = {
+        encoding: null, // disable auto `buffer.toString()` in package "request"
         url: target.href,
 //        url: 'http://httpbin.org/status/400',
         method: client_request.method,
@@ -171,7 +172,6 @@ function http_req_handler(client_request, client_response) {
 
     function handle_proxy_response_data(response, payload) {
         var filtered_headers = server_utils.filter_response_headers(response.headers);
-        filtered_headers['content-length'] = payload.length;
         client_response.writeHead(response.statusCode, filtered_headers);
         client_response.end(payload);
     }

--- a/server/utils.js
+++ b/server/utils.js
@@ -113,7 +113,6 @@ function filter_request_headers(headers) {
         }
     }
 
-    ret_headers['Accept-Encoding'] = 'deflate';
     return ret_headers;
 }
 


### PR DESCRIPTION
Fix https://github.com/Unblocker/Unblock-Youku/issues/491 by disabling auto `buf.toString()` within "request"

## 问题的原因

终于搞清楚了 https://github.com/Unblocker/Unblock-Youku/issues/491 的问题。
研究了好久，后来是看到了Request那边的这个Issue才收到了启发 https://github.com/request/request/issues/1680
问题的原因是Request没用对，或者可以说是Request包的默认行为比较奇怪吧~~~

Request那边对`gzip`和`encoding`这两个参数是这样写的：

> gzip - If true, add an Accept-Encoding header to request compressed content encodings from the server (if not already present) and decode supported content encodings in the response. 

> For backwards-compatibility, response compression is not supported by default. To accept gzip-compressed responses, set the gzip option to true. 

> encoding - Encoding to be used on setEncoding of response data. If null, the body is returned as a Buffer. Anything else (including the default value of undefined) will be passed as the encoding parameter to toString() (meaning this is effectively utf8 by default). (Note: if you expect binary data, you should set encoding: null.)

代码中也能看到确如文档所述，
 - 如果`gzip`参数没有设置，那么即使`content-encoding:gzip`，`responseBody`的buffer也不会被gunzip解压 ( https://github.com/request/request/blob/v2.64.1/request.js#L960 )
 - 如果`encoding`参数没有显式地设为`null`(`undefined`也不行)，那么`responseBody`的buffer会被自动`toString()`之后才交给callback ( https://github.com/request/request/blob/v2.64.1/request.js#L1036 )

放在这回issue中的场景，刚好浏览器`Accept-Encoding`支持`gzip`，youku和tudou那边也返回了`content-encoding: gzip`的response，再加上上面描述的`gzip`和`encoding`默认设置的行为，Request就直接对没有gunzip解压的buffer进行了`toString()`~~~~~ 然后responseBody就跪了 :sweat_smile: 

## 解决方案

该PR增加设置`encoding`为`null`，阻止Request将对Buffer进行`toString()`。callback函数获得的responseBody (代码中的 `payload`) 将保留为原始的 gzipped Buffer，并将该原始Buffer直接发给 proxy client。

经测试浏览器能够正确收到 gzipped response，youku和tudou也能够在转发模式下正确工作。

![fix-disable-auto-buffer-to-string](https://cloud.githubusercontent.com/assets/12769983/10410062/e4a926b6-6f70-11e5-99f3-0797f3251bcb.png)

经测试，还有另外几种能够解决 https://github.com/Unblocker/Unblock-Youku/issues/491 的方案，分别是
 - 强制使用`Accept-Encoding: identity`: https://github.com/xin-zhang/Unblock-Youku/pull/2
 - 给Request设置`gzip: true`参数，然后将Request解压之后的uncompressed response发给proxy client: https://github.com/xin-zhang/Unblock-Youku/pull/1
 - 在`gzip: true`的基础上，再在callback中重新把responseBody压成gzipped再发给proxy client

由于本PR设置`encoding: null`的解决方案有下面两个优点，因此提交了这个解决方案。
 - 在连接目标服务器和代理用户两端都尽可能地使用gzipped response，减少数据传输量
 - 避免在proxy无谓的解压和压缩

## 补足

1. 只要proxy没有对目标服务器发过来的responseBody进行解压或decode，`content-length`应该直接用原始的值就可以吧~~~ 
如果被解压了，重新计算`content-length`的话据我的理解和测试，好像也应该是`Buffer.byteLength(str)`，因为
> `Conteng-Length = Length(Entity-Body)
EntityBody := Content-Encoding( Content-Type( data ) )

2. 看到server/utils里原有的`ret_headers['Accept-Encoding'] = 'deflate';`是9月21日才加上去的，是尝试解决上面这个Issue所加的吗？感觉好像没用，因为Request好像也没有正确地处理deflate压缩的response body (根本没处理。。。)
https://github.com/Unblocker/Unblock-Youku/commit/1996359fa37c3a7b86ca39151906cc6049f0754f#diff-ee7d88bdd558c15575f4d4c4d63ff188R116

