### PR TITLE
small problem fix for letv live

### DIFF
--- a/shared/urls.js
+++ b/shared/urls.js
@@ -131,6 +131,7 @@ unblock_youku.common_urls = [
     'http://st.live.letv.com/live/*',
     'http://live.gslb.letv.com/gslb?*',
     'http://live.g3proxy.lecloud.com/gslb?*',
+    'http://api.live.letv.com/crossdomain.xml',
     'http://static.itv.letv.com/api*',
     'http://ip.apps.cntv.cn/js/player.do*',
     'http://vdn.apps.cntv.cn/api/get*',


### PR DESCRIPTION
之前有美国的用户反映没法看乐视直播，我测试了一下发现crossdomain.xml在海外地区会出现404，但使用国内的代理却没有问题。估计是跟之前的腾讯视频的那个问题相似，也是DNS配置出现故障了。因此暂时使用国内代理缓解一下这个问题。