### PR TITLE
Add new address for kuwo new web player

### DIFF
--- a/shared/urls.js
+++ b/shared/urls.js
@@ -119,6 +119,7 @@ unblock_youku.common_urls = [
     'http://www.xiami.com/play?*',
     'http://www.kugou.com/interface/geoip/checkip.php',
     'http://www.kuwo.cn/yy/PlayCheckIp?callback=checkIpCallback&_=*',
+    'http://antiserver.kuwo.cn/anti.s?*',
 
     'http://*.dpool.sina.com.cn/iplookup*',
     // 'http://*/vrs_flash.action*', //This URL hijackable!


### PR DESCRIPTION
发现通过酷我的歌手库、音乐库进入的时候页面会跟原有的不同(应该是新版页面），只要在里面点击任何一首歌曲，播放开始前都会自动跳转到新版主页。而原因就是上面的连接（原本用于返回歌曲真实地址）会返回IPDeny的结果。